### PR TITLE
MAST-1778 "Ntt wrapped mxf is missing additional header info"

### DIFF
--- a/src/AS_DCP_ATMOS.cpp
+++ b/src/AS_DCP_ATMOS.cpp
@@ -138,7 +138,7 @@ ASDCP::ATMOS::MXFReader::h__Reader::MD_to_DCData_DDesc(ASDCP::DCData::DCDataDesc
       assert(DDescObj->ContainerDuration <= 0xFFFFFFFFL);
       DDesc.ContainerDuration = static_cast<ui32_t>(DDescObj->ContainerDuration);
     }
-  memcpy(DDesc.DataEssenceCoding, DDescObj->DataEssenceCoding.Value(), SMPTE_UL_LENGTH);
+  memcpy(DDesc.DataEssenceCoding, DDescObj->DataEssenceCoding.const_get().Value(), SMPTE_UL_LENGTH);
   return RESULT_OK;
 }
 
@@ -431,7 +431,7 @@ ASDCP::ATMOS::MXFWriter::h__Writer::DCData_DDesc_to_MD(ASDCP::DCData::DCDataDesc
 
   DDescObj->SampleRate = DDesc.EditRate;
   DDescObj->ContainerDuration = DDesc.ContainerDuration;
-  DDescObj->DataEssenceCoding.Set(DDesc.DataEssenceCoding);  
+  DDescObj->DataEssenceCoding = DDesc.DataEssenceCoding;
   return RESULT_OK;
 }
 

--- a/src/AS_DCP_DCData.cpp
+++ b/src/AS_DCP_DCData.cpp
@@ -104,7 +104,7 @@ ASDCP::DCData::MXFReader::h__Reader::MD_to_DCData_DDesc(const MXF::DCDataDescrip
       assert(descriptor_object.ContainerDuration.const_get() <= 0xFFFFFFFFL);
       DDesc.ContainerDuration = static_cast<ui32_t>(descriptor_object.ContainerDuration.const_get());
     }
-  memcpy(DDesc.DataEssenceCoding, descriptor_object.DataEssenceCoding.Value(), SMPTE_UL_LENGTH);
+  memcpy(DDesc.DataEssenceCoding, descriptor_object.DataEssenceCoding.const_get().Value(), SMPTE_UL_LENGTH);
   return RESULT_OK;
 }
 
@@ -119,7 +119,7 @@ ASDCP::DCData::MXFReader::h__Reader::MD_to_DCData_DDesc(const MXF::PrivateDCData
       assert(descriptor_object.ContainerDuration.const_get() <= 0xFFFFFFFFL);
       DDesc.ContainerDuration = static_cast<ui32_t>(descriptor_object.ContainerDuration.const_get());
     }
-  memcpy(DDesc.DataEssenceCoding, descriptor_object.DataEssenceCoding.Value(), SMPTE_UL_LENGTH);
+  memcpy(DDesc.DataEssenceCoding, descriptor_object.DataEssenceCoding.const_get().Value(), SMPTE_UL_LENGTH);
   return RESULT_OK;
 }
 
@@ -402,7 +402,7 @@ ASDCP::DCData::MXFWriter::h__Writer::DCData_DDesc_to_MD(DCData::DCDataDescriptor
 
   DDescObj->SampleRate = DDesc.EditRate;
   DDescObj->ContainerDuration = DDesc.ContainerDuration;
-  DDescObj->DataEssenceCoding.Set(DDesc.DataEssenceCoding);
+  DDescObj->DataEssenceCoding = DDesc.DataEssenceCoding;
 
   return RESULT_OK;
 }

--- a/src/Metadata.cpp
+++ b/src/Metadata.cpp
@@ -3214,7 +3214,7 @@ GenericDataEssenceDescriptor::InitFromTLVSet(TLVReader& TLVSet)
 {
   assert(m_Dict);
   Result_t result = FileDescriptor::InitFromTLVSet(TLVSet);
-  if ( ASDCP_SUCCESS(result) ) result = TLVSet.ReadObject(OBJ_READ_ARGS(GenericDataEssenceDescriptor, DataEssenceCoding));
+  if ( ASDCP_SUCCESS(result) ) result = TLVSet.ReadObject(OBJ_READ_ARGS_OPT(GenericDataEssenceDescriptor, DataEssenceCoding));
   return result;
 }
 
@@ -3224,7 +3224,7 @@ GenericDataEssenceDescriptor::WriteToTLVSet(TLVWriter& TLVSet)
 {
   assert(m_Dict);
   Result_t result = FileDescriptor::WriteToTLVSet(TLVSet);
-  if ( ASDCP_SUCCESS(result) ) result = TLVSet.WriteObject(OBJ_WRITE_ARGS(GenericDataEssenceDescriptor, DataEssenceCoding));
+  if ( ASDCP_SUCCESS(result) && ! DataEssenceCoding.empty() )  result = TLVSet.WriteObject(OBJ_WRITE_ARGS_OPT(GenericDataEssenceDescriptor, DataEssenceCoding));
   return result;
 }
 
@@ -3254,7 +3254,7 @@ GenericDataEssenceDescriptor::Dump(FILE* stream)
     stream = stderr;
 
   FileDescriptor::Dump(stream);
-  fprintf(stream, "  %22s = %s\n",  "DataEssenceCoding", DataEssenceCoding.EncodeString(identbuf, IdentBufferLen));
+  fprintf(stream, "  %22s = %s\n",  "DataEssenceCoding", DataEssenceCoding.get().EncodeString(identbuf, IdentBufferLen));
 }
 
 //

--- a/src/Metadata.h
+++ b/src/Metadata.h
@@ -782,7 +782,7 @@ namespace ASDCP
 	  GenericDataEssenceDescriptor();
 
 	public:
-          UL DataEssenceCoding;
+          optional_property<UL > DataEssenceCoding;
 
       GenericDataEssenceDescriptor(const Dictionary* d);
       GenericDataEssenceDescriptor(const GenericDataEssenceDescriptor& rhs);

--- a/src/as-02-wrap.cpp
+++ b/src/as-02-wrap.cpp
@@ -1944,6 +1944,10 @@ write_timed_text_file(CommandOptions& Options)
       TDesc.EditRate = Options.edit_rate;
       TDesc.ContainerDuration = Options.duration;
       TDesc.LanguageList = Options.language.length() ? Options.language : Parser.GetLanguage();
+      if ( Options.asset_id_flag )
+	  memcpy(TDesc.AssetID, Options.asset_id_value, UUIDlen);
+      else
+	  Kumu::GenRandomUUID(TDesc.AssetID);
       FrameBuffer.Capacity(Options.fb_size);
 
       if ( ! Options.profile_name.empty() )
@@ -1963,10 +1967,7 @@ write_timed_text_file(CommandOptions& Options)
       WriterInfo Info = s_MyInfo;  // fill in your favorite identifiers here
       Info.LabelSetType = LS_MXF_SMPTE;
 
-      if ( Options.asset_id_flag )
-	memcpy(Info.AssetUUID, Options.asset_id_value, UUIDlen);
-      else
-	Kumu::GenRandomUUID(Info.AssetUUID);
+      memcpy(Info.AssetUUID, TDesc.AssetID, UUIDlen);
 
 #ifdef HAVE_OPENSSL
       // configure encryption


### PR DESCRIPTION
* Remove optional property DataEssenceCoding from TimedTextDescriptor when it's unspecified
* Set ResourceID value on TimedTextDescriptor with random generator or leverage '-a <uuid>' option